### PR TITLE
allow exclude crown dependency from correspondent registry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-*no unreleased changes*
+* allow exclude crown dependency from correspondent registry
 
 ## 1.0.4 / 2021-01-29
 ### Fixed

--- a/lib/tnql/grammars/registry.treetop
+++ b/lib/tnql/grammars/registry.treetop
@@ -1,7 +1,11 @@
 module Tnql
   grammar Registry
     rule registry
-      space registry:(registry_code / registry_abbr) <Nodes::RegistryNode>
+      exclude:exclude_crown_dependencies? space registry:(registry_code / registry_abbr) <Nodes::RegistryNode>
+    end
+
+    rule exclude_crown_dependencies
+      space ('not' / 'non' / 'exclude') space crown_dependency:('channel islands' / 'iom' / 'isle of man') <Nodes::ExcludeCrownDependencyNode>
     end
 
     rule registry_code

--- a/lib/tnql/nodes/registry.rb
+++ b/lib/tnql/nodes/registry.rb
@@ -2,7 +2,21 @@ module Tnql #:nodoc: all
   module Nodes
     module RegistryNode
       def meta_data_item
-        { 'tumour.registry' => { Tnql::EQUALS => registry.to_registrycode } }
+        registrycode = registry.to_registrycode
+        exclude_crown_dependency = !exclude.blank? && exclude.to_registrycode == registrycode
+        { 'tumour.registry' => { Tnql::EQUALS => [registrycode, exclude_crown_dependency] } }
+      end
+    end
+
+    module ExcludeCrownDependencyNode
+      CROWN_DEPENDENCY_REGISRY = {
+        'channel islands' => 'Y1001',
+        'iom' => 'Y1701',
+        'isle of man' => 'Y1701'
+      }.freeze unless defined?(CROWN_DEPENDENCY_REGISRY)
+
+      def to_registrycode
+        CROWN_DEPENDENCY_REGISRY[crown_dependency.text_value]
       end
     end
 

--- a/lib/tnql/nodes/registry.rb
+++ b/lib/tnql/nodes/registry.rb
@@ -9,14 +9,14 @@ module Tnql #:nodoc: all
     end
 
     module ExcludeCrownDependencyNode
-      CROWN_DEPENDENCY_REGISRY = {
+      CROWN_DEPENDENCY_REGISTRY = {
         'channel islands' => 'Y1001',
         'iom' => 'Y1701',
         'isle of man' => 'Y1701'
-      }.freeze unless defined?(CROWN_DEPENDENCY_REGISRY)
+      }.freeze unless defined?(CROWN_DEPENDENCY_REGISTRY)
 
       def to_registrycode
-        CROWN_DEPENDENCY_REGISRY[crown_dependency.text_value]
+        CROWN_DEPENDENCY_REGISTRY[crown_dependency.text_value]
       end
     end
 

--- a/test/nodes/registry_test.rb
+++ b/test/nodes/registry_test.rb
@@ -5,19 +5,41 @@ class RegistryTest < Minitest::Test
   def test_should_filter_by_registry_code
     parser = Tnql::Parser.new('all y0401 tumours')
     assert parser.valid?
-    assert_equal({ Tnql::EQUALS => 'Y0401' }, parser.meta_data['tumour.registry'])
+    assert_equal({ Tnql::EQUALS => ['Y0401', false] }, parser.meta_data['tumour.registry'])
   end
 
   def test_should_filter_by_registry_abbreviation
     parser = Tnql::Parser.new('all ecric tumours')
     assert parser.valid?
-    assert_equal({ Tnql::EQUALS => 'Y0401' }, parser.meta_data['tumour.registry'])
+    assert_equal({ Tnql::EQUALS => ['Y0401', false] }, parser.meta_data['tumour.registry'])
   end
 
   def test_should_filter_by_oxford_registry_abbreviation
     parser = Tnql::Parser.new('all oxford tumours')
     assert parser.valid?
-    assert_equal({ Tnql::EQUALS => 'Y0901' }, parser.meta_data['tumour.registry'])
+    assert_equal({ Tnql::EQUALS => ['Y0901', false] }, parser.meta_data['tumour.registry'])
+  end
+
+  def test_should_able_to_exclude_channel_islands_for_y1001_swcis
+    parser = Tnql::Parser.new('all non channel islands y1001 tumours')
+    assert parser.valid?
+    assert_equal({ Tnql::EQUALS => ['Y1001', true] }, parser.meta_data['tumour.registry'])
+  end
+
+  def test_should_able_to_exclude_isle_of_man_for_y1701_nwcis
+    parser = Tnql::Parser.new('all exclude iom nwcis tumours')
+    assert parser.valid?
+    assert_equal({ Tnql::EQUALS => ['Y1701', true] }, parser.meta_data['tumour.registry'])
+
+    parser = Tnql::Parser.new('all not isle of man y1701 tumours')
+    assert parser.valid?
+    assert_equal({ Tnql::EQUALS => ['Y1701', true] }, parser.meta_data['tumour.registry'])
+  end
+
+  def test_should_not_exclude_if_regirsty_doesnot_have_crown_dependency
+    parser = Tnql::Parser.new('all exclude channel islands ecric tumours')
+    assert parser.valid?
+    assert_equal({ Tnql::EQUALS => ['Y0401', false] }, parser.meta_data['tumour.registry'])
   end
 
   def test_should_filter_by_registry_equivalences


### PR DESCRIPTION
https://ncr.plan.io/issues/25434

keywords: not / non / exclude
islands:  channel islands / iom / isle of man

exclusion only applies when island matches registry, e.g. channel islands -> Y1001