### PR TITLE
update rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,1 @@
-inherit_from: 'https://raw.githubusercontent.com/PublicHealthEngland/ndr_dev_support/master/.rubocop.yml'
-
-Rails:
-  Enabled: false
-
-AllCops:
-  TargetRubyVersion: 2.3
+require: ndr_dev_support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-*no unreleased changes*
+* update rubocop configuration
 
 ## 1.0.4 / 2021-01-29
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 * update rubocop configuration
+* bump dependent gem `ndr_dev_support` to v6.0
 
 ## 1.0.4 / 2021-01-29
 ### Fixed

--- a/tnql.gemspec
+++ b/tnql.gemspec
@@ -1,5 +1,5 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'tnql/version'
 
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'treetop', '>= 1.4.10'
   spec.add_dependency 'chronic', '~> 0.3'
 
-  spec.add_development_dependency 'ndr_dev_support', '~> 5.9'
+  spec.add_development_dependency 'ndr_dev_support', '~> 6.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest', '>= 5.0.0'


### PR DESCRIPTION
get latest config from `ndr_dev_support`